### PR TITLE
Decouple TransitionScheduler and Transition for #9

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,8 +5,8 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 27
-        versionCode 2
-        versionName "0.2"
+        versionCode 3
+        versionName "0.3"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,8 +5,8 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 27
-        versionCode 1
-        versionName "0.1"
+        versionCode 2
+        versionName "0.2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/library/src/main/java/org/libreshift/transition/TransitionScheduler.java
+++ b/library/src/main/java/org/libreshift/transition/TransitionScheduler.java
@@ -28,8 +28,6 @@ public abstract class TransitionScheduler extends BroadcastReceiver {
     // since alarms may be delayed
     abstract void onAlarm(String id, long startTime, long duration);
 
-    // Is UPDATE_CURRENT the right flag? Red Moon was using the constant '0',
-    // which doesn't match the constant of *any* of the PendingIntent flags..
     static final int FLAG = PendingIntent.FLAG_UPDATE_CURRENT;
 
     @Override
@@ -55,13 +53,12 @@ public abstract class TransitionScheduler extends BroadcastReceiver {
 
     // Passing an id of an alarm that is already scheduled will overwrite that alarm
     public void schedule(Context context, String id, long startTime, long duration) {
-        // TODO: If there's already an alarm scheduled, should we return the old time?
-
         long now = System.currentTimeMillis();
         long endTime = startTime + duration;
         if (now >= endTime) {
-            return; // TODO: Should we do anything here?
+            return;
         }
+
         SharedPreferences prefs = getPrefs(context);
         Set<String> ids = new HashSet<>(prefs.getStringSet(IDS, new HashSet<String>()));
         String id_start = id + START;

--- a/library/src/main/java/org/libreshift/transition/TransitionScheduler.java
+++ b/library/src/main/java/org/libreshift/transition/TransitionScheduler.java
@@ -17,9 +17,9 @@ public abstract class TransitionScheduler extends BroadcastReceiver {
 
     static final String TAG = "TransitionScheduler";
     static final String ACTION_ALARM = "org.libreshift.transition.ACTION_ALARM";
-    static final String IDS = "IDS";
-    static final String START = "_START";
-    static final String DURATION = "_DURATION";
+    private static final String IDS = "IDS";
+    private static final String START = "_START";
+    private static final String DURATION = "_DURATION";
 
     // One hour; override for a different default
     static long DURATION_DEFAULT = 3600000;
@@ -99,7 +99,7 @@ public abstract class TransitionScheduler extends BroadcastReceiver {
         prefs.edit().putStringSet(IDS, ids).remove(id_start).remove(id_duration).apply();
     }
 
-    void reschedule(Context context) {
+    public void reschedule(Context context) {
         SharedPreferences prefs = getPrefs(context);
         Set<String> ids = prefs.getStringSet(IDS, new HashSet<String>());
 
@@ -123,5 +123,5 @@ public abstract class TransitionScheduler extends BroadcastReceiver {
         return context.getSharedPreferences(PREFERENCE, Context.MODE_PRIVATE);
     }
 
-    static final String PREFERENCE = "org.libreshift.transition.preference";
+    private static final String PREFERENCE = "org.libreshift.transition.preference";
 }


### PR DESCRIPTION
Also, increment version numbers, make some constants private, and make `reschedule()` public.